### PR TITLE
New aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Aliases
   * `pacol` list orphan packages
   * `pacor` remove all orphan packages
 
+### Database
+  * `pacpexp` mark packages as explicitly installed
+  * `pacpdep` mark packages as non-explicitly installed or as dependency
+
 ### Ownership
 
   * `pacown` list all files provided by a given package

--- a/init.zsh
+++ b/init.zsh
@@ -106,6 +106,16 @@
   # remove orphan packages
   alias pacor="${zpacman_frontend_priv} -Rns \$(pacman -Qtdq)"
 
+  #
+  #Database
+  #
+
+  #mark packages as explicitly installed
+  alias pacpexp="${zpacman_frontend_priv} -D --asexplicit"
+
+  #mark packages as non-explicitly installed or dependency
+  alias pacpdep="${zpacman_frontend_priv} -D --asedps"
+
 
   #
   # Ownership


### PR DESCRIPTION
Hi I add two new alias that I think are useful, one for mark packages as explicitly installed and another for non-explicitly installed.
I think this is useful when you want to conserve a package that got orphan, or vice versa. 